### PR TITLE
Add setup instructions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# OpenAI API key used by the chat endpoint
+OPENAI_API_KEY=your-openai-api-key
+
+# Clerk authentication keys
+NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=your-clerk-publishable-key
+CLERK_SECRET_KEY=your-clerk-secret-key

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -1,0 +1,62 @@
+# Stonksville
+
+Stonksville is a Next.js application that visualizes financial data and provides chat driven insights using OpenAI. Authentication is handled by Clerk. Charts and other components are written in TypeScript and use Tailwind CSS.
+
+## Prerequisites
+
+- Node.js 18 or higher
+- npm (comes with Node) or pnpm
+- An OpenAI API key
+- Clerk credentials (publishable key and secret key)
+
+## Installation
+
+1. **Install dependencies**
+   ```bash
+   npm install
+   ```
+   or using pnpm:
+   ```bash
+   pnpm install
+   ```
+
+2. **Create an environment file**
+   Copy `.env.example` to `.env.local` and fill in the required values.
+   ```bash
+   cp .env.example .env.local
+   ```
+
+3. **Populate environment variables**
+   Open `.env.local` and provide your API keys.
+
+## Running the project
+
+Start the development server with:
+
+```bash
+npm run dev
+```
+
+or
+
+```bash
+pnpm dev
+```
+
+The application will be available at `http://localhost:3000` by default.
+
+### Scripts
+
+- `npm run dev` – start the development server
+- `npm run lint` – run ESLint
+- `npm run build` – create a production build
+- `npm start` – run the built application
+
+## Notes
+
+- The file `lib/constants.ts` contains the base URL for the backend API (`https://dev-api.agentsmyth.com`). If you need to point to another API, adjust the `API_URL` constant.
+- The project relies on Google Fonts during build time. If the build fails due to network restrictions (unable to download fonts), either allow access to `fonts.gstatic.com` or replace the fonts with local copies in `app/layout.tsx`.
+
+## License
+
+MIT


### PR DESCRIPTION
## Summary
- add README with local setup instructions and useful notes
- commit example env file
- allow `.env.example` in `.gitignore`

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font file from fonts.gstatic.com)*

------
https://chatgpt.com/codex/tasks/task_b_687d1e33a49c8333916dc1bd6b680b35